### PR TITLE
feat: third party integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,28 @@ You can set the message types that will show up on each tab, and you can set mes
 
 ![](https://camo.githubusercontent.com/c9488694f8ea5c0b153257e894a0bd114fd4e02411c81b49f5aef4ddce554df8/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f313130363333383731353434373539393136352f313130363733323936303434343538383039322f416e696d6163616f31302e676966)
 
+## To integrate with Customizable Chat Tabs
+Your module should call on `init` hook `window.tabbedchat.register(key: string, name?: string, desctipion?: string)` function.
+
+Arguments:\
+- `key` - name of you module
+- `name` - user friendly name. It will show in settings
+- `description` - Some additional text under module name in settings
+
+Example:
+```javascript
+Hooks.on("init", () => {
+  window.tabbedchat.register('custom-module', 'Custom module', 'My custom module')
+});
+```
+
+Any messages that your module will create should have flag "module" with key you have been used in `register` function. That messages would respect tab settings for your module.
+```javascript
+await ChatMessage.create({ 
+    content: 'Hello world',
+    flags: { module: 'custom-module' } 
+});
+```
+
 ## Attribution
 This is a fork of [Tabbed Chatlog](https://github.com/cswendrowski/FoundryVTT-Tabbed-Chatlog).

--- a/chat-tabs.js
+++ b/chat-tabs.js
@@ -111,19 +111,6 @@ class ChatTab {
 		return Boolean(this.sources.find(source => source.canShowMessage(message)))
 	}
 
-	reset() {
-		const messagesToHide = []
-		const messagesToShow = []
-
-		game.messages.forEach(message => {
-			this.isMessageVisible(message) ? messagesToShow.push(message) : messagesToHide.push(message)
-		})
-
-		const messageSelector = (message) => `#chat-log .message[data-message-id=${message.id}]`
-		$(messagesToHide.map(messageSelector).join(', ')).css({display: 'none'})
-		$(messagesToShow.map(messageSelector).join(', ')).css({display: ''})
-	}
-
 	setNotification() {
 		const nTabs = $("nav.tabbedchatlog.tabs > a.item").length;
 		$(`#${this.id}Notification`).css({ display: "" });
@@ -339,7 +326,7 @@ class TabbedChatlog {
 			initial: "ic",
 			callback: (event, html, tabName) => {
 				this.currentTab = tabName;
-				this.currentTab.reset()
+				game.messages.forEach(message => this.currentTab.handle(message))
 				if (!this.currentTab.canUserWrite()) $("#chat-message").prop("disabled", true);
 				else if ($("#chat-message").is(":disabled")) $("#chat-message").prop("disabled", false);
 

--- a/templates/ChatTabs.hbs
+++ b/templates/ChatTabs.hbs
@@ -27,14 +27,15 @@
 				</div>
 				<h2 class="tc-collapse-label">{{localize "TC.SETTINGS.ChatTabsSettings.MessageTypes"}}</h2>
 				<div>
-					{{#each tab.messageTypes as |obj id|}}
+					{{#each tab.sources as |source id|}}
 						<div class="form-group">
-							<label>{{obj.label}}</label>
-							<input name="tabs.{{key}}.messageTypes.{{id}}" type="checkbox" {{checked obj.value}} />
-							<p class="notes">{{obj.hint}}</p>
+							<label>{{source.label}}</label>
+							<input name="tabs.{{key}}.sources.{{id}}" type="checkbox" {{checked source.value}} />
+							<p class="notes">{{source.hint}}</p>
 						</div>
 					{{/each}}
 				</div>
+
 				<h2 class="tc-collapse-label">{{localize "TC.SETTINGS.ChatTabsSettings.RolePermissions"}}</h2>
 				<div>
 					{{#each tab.permissions.roles as |obj id|}}


### PR DESCRIPTION
Feats:
- add new function `window.tabbedchat.register` to easy integrating with **Customizable Chat Tabs**
- add new abstraction `ChatTabSource` to easily defining type of message
- add new property `sources` to `game.tabbedchat`. It contains all available sources of messages
- `ChatTab` new property `sources[ChatTabSource]` to validate visibility state of any messages
- `ChatTab` new method `handle`, `show`, `hide` to set message visibility. `handle` is just helper for calling `show` and `hide` depending on tab settings
- settings `Message Type` now depends on `game.tabbedchat.sources`
- settings has new format. `messageTypes[int]` has been removed. `sources[string]` has been add. Compatibility with old version of settings is saved.

Fix:
- if message showing in more than one tabs, notify was sent only for one of them. Now notify works for every tabs.

Refactor:
- remove DOM logic inside hooks
- remove code duplicating

Notes:
- logic depends on game systems must be removed from hooks. Better idea use factory methods.