### PR TITLE
Set a default when there's no polyglot flag

### DIFF
--- a/chat-tabs.js
+++ b/chat-tabs.js
@@ -547,7 +547,7 @@ function sendToDiscord(webhook, body) {
 }
 
 function convertPolyglotMessage(chatMessage) {
-	const lang = chatMessage.getFlag("polyglot", "language");
+	const lang = chatMessage.getFlag("polyglot", "language") || game.polyglot.defaultLanguage;
 	let message = chatMessage.content;
 	if (lang !== game.polyglot.defaultLanguage) {
 		message = game.polyglot.languages[lang].label + ": ||" + message + "||";


### PR DESCRIPTION
When a chat message is sent without a selected token, or when there's no token in the scene, `const lang` may end up as `undefined`.