### PR TITLE
Check for privileges in getValidTab

### DIFF
--- a/chat-tabs.js
+++ b/chat-tabs.js
@@ -579,7 +579,7 @@ function generatePortraitImageElement(actor) {
 
 function getValidTab(chatMessage) {
 	return game.chatTabs.tabs.find((tab) =>
-		tab.sources.find((source) => source.canShowMessageNonExclusively(chatMessage))
+		tab.sources.find((source) => tab.permissions.users[chatMessage.user._id] === 2 && source.canShowMessageNonExclusively(chatMessage))
 	);
 }
 


### PR DESCRIPTION
Otherwise, messages could end up posted to a tab that a user can't write to, since `find()` just returns the first match.